### PR TITLE
ZENREACH-182: New Client Function With Host Parameter

### DIFF
--- a/plivo/plivo.go
+++ b/plivo/plivo.go
@@ -16,7 +16,8 @@ import (
 
 const (
 	libraryVersion = "0.1"
-	defaultBaseURL = "https://api.plivo.com/%s/Account/"
+	defaultHost    = "api.plivo.com"
+	defaultBaseURL = "https://%s/%s/Account/"
 	userAgent      = "go-plivo/" + libraryVersion
 	apiVersion     = "v1"
 )
@@ -47,7 +48,12 @@ type Client struct {
 
 // NewClient returns a new Plivo API client. If client is nil, http.DefaultClient will be used.
 func NewClient(client *http.Client, authID, authToken string) *Client {
-	baseURL, _ := url.Parse(fmt.Sprintf(defaultBaseURL, apiVersion))
+	return NewClientWithHost(client, authID, authToken, defaultHost)
+}
+
+// NewClientWithHost returns a new Plivo API client with specified host.
+func NewClientWithHost(client *http.Client, authID, authToken string, host string) *Client {
+	baseURL, _ := url.Parse(fmt.Sprintf(defaultBaseURL, host, apiVersion))
 
 	if client == nil {
 		client = http.DefaultClient


### PR DESCRIPTION
added client function that can take in a different host (for mocking) without affecting current use of NewClient function.